### PR TITLE
Add test CanParseLikeJavaReference

### DIFF
--- a/source/JavaPropertiesParser.Tests/JavaPropertiesParser.Tests.csproj
+++ b/source/JavaPropertiesParser.Tests/JavaPropertiesParser.Tests.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <EmbeddedResource Include="Resources\*.properties" />
+      <EmbeddedResource Include="Resources\*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/JavaPropertiesParser.Tests/Resources/parser-stress-reference-interpretation.xml
+++ b/source/JavaPropertiesParser.Tests/Resources/parser-stress-reference-interpretation.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<entry key="">emptykey</entry>
+<entry key="euro">€</entry>
+<entry key="cheeses"></entry>
+<entry key="separate">tab</entry>
+<entry key="fruit">banana</entry>
+<entry key="leading">and trailing spaces    </entry>
+<entry key="&quot;quoted">key"="does not work"</entry>
+<entry key="3first">:separator wins</entry>
+<entry key="two">word line</entry>
+<entry key="three">word line</entry>
+<entry key="Truth1">Beauty</entry>
+<entry key="Truth2">Beauty</entry>
+<entry key="punctuation:=
+\
+	key">punctuation:=
+\
+	value</entry>
+<entry key="fruits">apple, banana, pear, cantaloupe, watermelon, kiwi, mango</entry>
+<entry key="four">word line #noncomment</entry>
+<entry key="quotedvalue">"this"</entry>
+<entry key="Truth3">Beauty</entry>
+<entry key="2first">: separator wins</entry>
+<entry key="sunnies">&#xd83d;&#xde0e;</entry>
+<entry key="dagger">†</entry>
+<entry key=" trimmedkey ">no</entry>
+<entry key="unnecessary">escapes '"ignored'"</entry>
+<entry key="joinedlines">onetwo two#three three threefour four four four    five</entry>
+<entry key="ending">with backslash\</entry>
+<entry key="1first">= separator wins</entry>
+<entry key="indentyes1">	here </entry>
+<entry key="indentyes2"> here </entry>
+<entry key="multiline">line one
+line two
+line three</entry>
+<entry key="colon">value</entry>
+<entry key="indentno2">here </entry>
+<entry key="indentno1">here </entry>
+<entry key="space-around-sep">trimmed</entry>
+<entry key="	tabtrimmedkey	">no</entry>
+</properties>

--- a/source/JavaPropertiesParser.Tests/Resources/parser-stress.properties
+++ b/source/JavaPropertiesParser.Tests/Resources/parser-stress.properties
@@ -1,0 +1,47 @@
+Truth1 = Beauty
+Truth2:Beauty
+Truth3                    :Beauty
+fruits                           apple, banana, pear, \
+                                  cantaloupe, watermelon, \
+                                  kiwi, mango
+cheeses
+fruit=banana
+dagger: \u2020
+sunnies: \uD83D\uDE0E
+euro: \u20ac
+!comment comment comment \
+two word line
+
+   
+  	  
+three word line
+# comment
+four word line #noncomment
+  leading    and trailing spaces    
+ # indented comment
+joinedlines=one\
+ two two\
+  #three three three\
+four four four four    \
+five\
+  
+multiline=line one\nline two\nline three
+colon:value
+"quoted key"="does not work"
+quotedvalue="this"
+1first:= separator wins
+2first=: separator wins
+3first =:separator wins
+unnecessary esc\apes '\"ignored\'"
+ending:with backslash\\
+separate	tab
+punctuation\:\r\=\n\\\r\n\	key punctuation\:\r\=\n\\\r\n\	value
+indentno1=  here 
+indentno2=	here 
+indentyes1=\	here 
+indentyes2=\ here 
+:  emptykey
+\ trimmedkey\ :no
+\ttabtrimmedkey\t:no
+space-around-sep     =    trimmed
+


### PR DESCRIPTION
This tests the parser against a reference XML file generated in Java with `Properties.storeToXML()`.