### PR TITLE
Fix empty package / project name for scheduled event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,8 @@ env:
   OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref }}
   OCTOVERSION_Patch: ${{ github.run_number }}
   OCTOPUSDEPLOY_Space: "Core Platform"
-  OCTOPUSDEPLOY_Project: ${GITHUB_REPOSITORY#*/} #Update when git & 🐙 deploy project name are not matching. 
-  OCTOPUSDEPLOY_Package: ${GITHUB_REPOSITORY#*/} #GITHUB_REPOSITORY returns owner/repo-name. This will strip owner and retain repo-name.
+  OCTOPUSDEPLOY_Project: ${{github.repository#*/}} #Update when git & 🐙 deploy project name are not matching. 
+  OCTOPUSDEPLOY_Package: ${{github.repository#*/}} #GITHUB_REPOSITORY returns owner/repo-name. This will strip owner and retain repo-name.
 
 jobs:
   test-windows:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,6 @@ on:
 env:
   OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref }}
   OCTOVERSION_Patch: ${{ github.run_number }}
-  OCTOPUSDEPLOY_Space: "Core Platform"
-  OCTOPUSDEPLOY_Project: ${{github.repository#*/}} #Update when git & 🐙 deploy project name are not matching. 
-  OCTOPUSDEPLOY_Package: ${{github.repository#*/}} #GITHUB_REPOSITORY returns owner/repo-name. This will strip owner and retain repo-name.
 
 jobs:
   test-windows:
@@ -100,6 +97,16 @@ jobs:
       uses: OctopusDeploy/install-octopus-cli-action@v1
       with:
         version: latest
+
+    - name: Set Octopus Related ENV
+      #Set Octopus Deploy Space Name
+      #Set Octopus Deploy Project Name
+      #Set Package Name  
+      #GITHUB_REPOSITORY returns owner/repo-name. This will strip owner and retain repo-name. (IE: OctopusDeploy/JavaPropertiesParser = JavaPropertiesParser)      
+      run: |
+        echo "OCTOPUSDEPLOY_Space=Core Platform" >> $GITHUB_ENV
+        echo "OCTOPUSDEPLOY_Project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+        echo "OCTOPUSDEPLOY_Package=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Push to Octopus 🐙
       uses: OctopusDeploy/push-package-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,8 @@ env:
   OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref }}
   OCTOVERSION_Patch: ${{ github.run_number }}
   OCTOPUSDEPLOY_Space: "Core Platform"
-  OCTOPUSDEPLOY_Project: ${{ github.event.repository.name }} #Update when git & 🐙 deploy project name are not matching. 
-  OCTOPUSDEPLOY_Package: ${{ github.event.repository.name }}
+  OCTOPUSDEPLOY_Project: ${GITHUB_REPOSITORY#*/} #Update when git & 🐙 deploy project name are not matching. 
+  OCTOPUSDEPLOY_Package: ${GITHUB_REPOSITORY#*/} #GITHUB_REPOSITORY returns owner/repo-name. This will strip owner and retain repo-name.
 
 jobs:
   test-windows:


### PR DESCRIPTION
An issue was identified where `github.event` context for a `schedule` does not contain `repository` information. (Open discussion in [github-community](https://github.com/community/community/discussions/12269))

This is to address the issue by utilising [bash parameter expansion](https://stackoverflow.com/questions/19482123/extract-part-of-a-string-using-bash-cut-split/19482947#19482947)