### PR TITLE
Updated the nuget package id so that it is now Octopus.JavaPropertiesParse. This should eleviate the Dependency Confusion security concern

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
       run: |
         echo "OCTOPUSDEPLOY_Space=Core Platform" >> $GITHUB_ENV
         echo "OCTOPUSDEPLOY_Project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
-        echo "OCTOPUSDEPLOY_Package=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+        echo "OCTOPUSDEPLOY_Package=Octopus.JavaPropertiesParser" >> $GITHUB_ENV
 
     - name: Push to Octopus 🐙
       uses: OctopusDeploy/push-package-action@v1

--- a/source/JavaPropertiesParser/JavaPropertiesParser.csproj
+++ b/source/JavaPropertiesParser/JavaPropertiesParser.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <AssemblyName>JavaPropertiesParser</AssemblyName>
         <RootNamespace>JavaPropertiesParser</RootNamespace>
         <Authors>Octopus Deploy</Authors>
+	    <PackageId>Octopus.JavaPropertiesParser</PackageId>
         <PackageProjectUrl>https://github.com/OctopusDeploy/JavaPropertiesParser</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
Update the package name so that it is in our registered Octopus prefix. 