### PR TITLE
Use OIDC to connect to octopus

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
     # Adjustment is done prior to Nuke build as OCTOVERSION information is included in the result package.
     - name: Append OCTOVERSION_CurrentBranch with -nightly (for scheduled)
       if: github.event_name == 'schedule'
-      run: echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly" >> $GITHUB_ENV
+      run: echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
     - name: Nuke Build 🏗
       id: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,9 +52,11 @@ jobs:
   build-release-linux:
     needs: test-windows
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required to obtain the ID token from GitHub Actions
+      contents: read # Required to check out code
+      checks: write # Required for test-reporter
     env:
-      OCTOPUS_API_KEY: ${{ secrets.DEPLOY_API_KEY }}
-      OCTOPUS_URL: ${{ secrets.DEPLOY_URL }}
       OCTOPUS_SPACE: "Core Platform"
     steps:
     - uses: actions/checkout@v4
@@ -97,13 +99,22 @@ jobs:
             sha: context.sha
           })
 
+    - name: Login to Octopus Deploy 🐙
+      if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
+      uses: OctopusDeploy/login@v1
+      with: 
+        server: https://deploy.octopus.app
+        service_account_id: 68b2db4c-06d7-4340-af7a-2e3142930c10
+
     - name: Push to Octopus 🐙
+      if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
       uses: OctopusDeploy/push-package-action@v3
       with:
         packages: |
           ./artifacts/Octopus.JavaPropertiesParser.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg          
 
     - name: Create Release in Octopus 🐙
+      if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
       uses: OctopusDeploy/create-release-action@v3
       with:
         project: JavaPropertiesParser


### PR DESCRIPTION
## Background

Our API keys periodically expire, breaking things.

## Results

Octopus now supports OIDC for github actions, with wildcards on permitted branches, enabling us to authenticate via OIDC and remove the need for API keys entirely.
You can see it in action on this branch build: https://github.com/OctopusDeploy/JavaPropertiesParser/actions/runs/7634269738